### PR TITLE
Crossvalidation holes

### DIFF
--- a/R/R/diagnostics.R
+++ b/R/R/diagnostics.R
@@ -80,6 +80,9 @@ simulated_historical_forecasts <- function(model, horizon, units, k,
     m <- prophet_copy(model, cutoff)
     # Train model
     history.c <- dplyr::filter(df, ds <= cutoff)
+    # Instead of exiting the program with an error when we do not have two data points within the horizon,
+    # we will simply not make a prediction and advance to the next data point. 
+    if(nrow(history.c)<2) next
     m <- fit.prophet(m, history.c)
     # Calculate yhat
     df.predict <- dplyr::filter(df, ds > cutoff, ds <= cutoff + horizon)

--- a/python/fbprophet/diagnostics.py
+++ b/python/fbprophet/diagnostics.py
@@ -90,6 +90,9 @@ def simulated_historical_forecasts(model, horizon, k, period=None):
         # Generate new object with copying fitting options
         m = model.copy(cutoff)
         # Train model
+        subset = df[df['ds'] <= cutoff]
+        if subset.shape[0] < 2:
+            continue
         m.fit(df[df['ds'] <= cutoff])
         # Calculate yhat
         index_predicted = (df['ds'] > cutoff) & (df['ds'] <= cutoff + horizon)


### PR DESCRIPTION
Minor change to both the Python and R versions where instead of exiting with an error, the program will move to the next time point when it encounters a time interval larger than the cross-validation horizon at the beginning of the procedure.